### PR TITLE
[nrf noup] dev-apis: platform: Increase timeout for nRF devs

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
@@ -23,10 +23,12 @@ uart.0.base = 0; // Unused value
 watchdog.num = 1;
 watchdog.0.base = 0x40018000; // Unused value
 watchdog.0.num_of_tick_per_micro_sec = 1;
-watchdog.0.timeout_in_micro_sec_low = 1000000; // 1.0 secs
-watchdog.0.timeout_in_micro_sec_medium = 2000000;  // 2 secs
-watchdog.0.timeout_in_micro_sec_high = 600000000; // 60 secs
-watchdog.0.timeout_in_micro_sec_crypto = 90000000; // 90 secs
+// The same value should be used for all timeout durations, as the nRF91
+// WDT cannot be reconfigured once it has been started.
+watchdog.0.timeout_in_micro_sec_low    = 900000000; // 900 secs
+watchdog.0.timeout_in_micro_sec_medium = 900000000;
+watchdog.0.timeout_in_micro_sec_high   = 900000000;
+watchdog.0.timeout_in_micro_sec_crypto = 900000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
@@ -25,10 +25,10 @@ watchdog.0.base = 0x40018000;
 watchdog.0.num_of_tick_per_micro_sec = 1;
 // The same value should be used for all timeout durations, as the nRF91
 // WDT cannot be reconfigured once it has been started.
-watchdog.0.timeout_in_micro_sec_low = 90000000; // 90 secs
-watchdog.0.timeout_in_micro_sec_medium = 90000000;
-watchdog.0.timeout_in_micro_sec_high = 90000000;
-watchdog.0.timeout_in_micro_sec_crypto = 90000000;
+watchdog.0.timeout_in_micro_sec_low    = 900000000; // 900 secs
+watchdog.0.timeout_in_micro_sec_medium = 900000000;
+watchdog.0.timeout_in_micro_sec_high   = 900000000;
+watchdog.0.timeout_in_micro_sec_crypto = 900000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_ff_tfm_nrf5340/target.cfg
+++ b/api-tests/platform/targets/tgt_ff_tfm_nrf5340/target.cfg
@@ -26,10 +26,12 @@ uart.0.base = 0; // Unused value
 watchdog.num = 1;
 watchdog.0.base = 0x50018000; // Secure WDT0
 watchdog.0.num_of_tick_per_micro_sec = 0; // Unused
-watchdog.0.timeout_in_micro_sec_low = 1000000; // 1.0 secs
-watchdog.0.timeout_in_micro_sec_medium = 2000000;  // 2 secs
-watchdog.0.timeout_in_micro_sec_high = 5000000; // 5 secs
-watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
+// The same value should be used for all timeout durations, as the nRF91
+// WDT cannot be reconfigured once it has been started.
+watchdog.0.timeout_in_micro_sec_low    = 900000000; // 900 secs
+watchdog.0.timeout_in_micro_sec_medium = 900000000;
+watchdog.0.timeout_in_micro_sec_high   = 900000000;
+watchdog.0.timeout_in_micro_sec_crypto = 900000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_ff_tfm_nrf9160/target.cfg
+++ b/api-tests/platform/targets/tgt_ff_tfm_nrf9160/target.cfg
@@ -28,10 +28,10 @@ watchdog.0.base = 0x50018000;
 watchdog.0.num_of_tick_per_micro_sec = 1;
 // The same value should be used for all timeout durations, as the nRF91
 // WDT cannot be reconfigured once it has been started.
-watchdog.0.timeout_in_micro_sec_low = 18000000; // 18 secs
-watchdog.0.timeout_in_micro_sec_medium = 18000000;  // 18 secs
-watchdog.0.timeout_in_micro_sec_high = 18000000; // 18 secs
-watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
+watchdog.0.timeout_in_micro_sec_low    = 900000000; // 900 secs
+watchdog.0.timeout_in_micro_sec_medium = 900000000;
+watchdog.0.timeout_in_micro_sec_high   = 900000000;
+watchdog.0.timeout_in_micro_sec_crypto = 900000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;


### PR DESCRIPTION
Increase the timeout for the nRF5340/nRF9160 devices. RSA keygen will sometimes take more than 90 seconds.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>